### PR TITLE
商品情報編集機能・１

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ belong_to :purchase_management
 | price            | integer   | null: false                    |
 | description      | text      | null: false                    |
 | status_id        | integer   | null: false                    |
-| sipping_cost_id  | integer   | null: false                    |
+| shipping_cost_id | integer   | null: false                    |
 | shipping_days_id | integer   | null: false                    |
 | user             | references | null: false, foreign_key: true |
 | category_id      | integer   | null: false                    |

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,9 +2,9 @@ class ItemsController < ApplicationController
 
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item,only: [:show,:edit,:update]
-  before_action :item_seller_confirmation,only: [:edot,:update]
+  before_action :item_seller_confirmation,only: [:edit,:update]
 
-  # before_action :move_to_index, except: [:index :show]
+  
 
 
   def index
@@ -52,15 +52,7 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:image,:name, :price, :description, :status_id, :shipping_cost_id, :shipping_day_id, :category_id, :prefecture_id).merge(user_id: current_user.id)
   end
 
-  def move_to_index
-    redirect_to action: :index
-    if @item.save
-      redirect_to edit_item
-    else
-      render :new
-    end
-  end
-
+  
    def set_item
      @item = Item.find(params[:id])
    end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
 
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :move_to_index, except: [:index, :show]
+  # before_action :move_to_index, except: [:index :show]
 
 
   def index
@@ -9,7 +9,7 @@ class ItemsController < ApplicationController
   end
 
   def new
-    
+    @item = Item.new
   end
 
   def create
@@ -25,6 +25,26 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  
+    
+    def edit
+      @item = Item.find(params[:id])
+      redirect_to root_path unless current_user.id == @item.user_id
+    end
+
+    def update
+      @item = Item.find(params[:id])
+
+    
+      if @item.update(item_params)
+        redirect_to root_path
+      else
+        render :edit
+      end
+      redirect_to item_path unless current_user.id == @item.user_id
+    end
+
+
   # def destroy
   #   @item.destroy
   #   redirect_to root_path
@@ -37,6 +57,14 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:image,:name, :price, :description, :status_id, :shipping_cost_id, :shipping_day_id, :category_id, :prefecture_id).merge(user_id: current_user.id)
   end
 
-  
+  def move_to_index
+    redirect_to action: :index
+    if @item.save
+      redirect_to edit_item
+    else
+      render :new
+    end
+
+  end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,9 @@
 class ItemsController < ApplicationController
 
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_item,only: [:show,:edit,:update]
+  before_action :item_seller_confirmation,only: [:edot,:update]
+
   # before_action :move_to_index, except: [:index :show]
 
 
@@ -21,27 +24,19 @@ class ItemsController < ApplicationController
     end
   end
 
-  def show
-    @item = Item.find(params[:id])
-  end
-
-  
+   def show
+   end
     
     def edit
-      @item = Item.find(params[:id])
-      redirect_to root_path unless current_user.id == @item.user_id
-    end
-
+    end 
+      
     def update
-      @item = Item.find(params[:id])
-
-    
       if @item.update(item_params)
         redirect_to root_path
       else
         render :edit
       end
-      redirect_to item_path unless current_user.id == @item.user_id
+      
     end
 
 
@@ -64,7 +59,14 @@ class ItemsController < ApplicationController
     else
       render :new
     end
-
   end
 
+   def set_item
+     @item = Item.find(params[:id])
+   end
+
+  def item_seller_confirmation
+    redirect_to root_path unless current_user.id == @item.user_id
+  end
+    
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -9,10 +9,9 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with(model: @item, local: true) do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-
+    
     <%# 出品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,10 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with(model: @item, local: true) do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_cost_id, ShippingCost.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_day_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,21 +16,18 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price%>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_cost.name  %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
     <%# <% 'ユーザーがログインしている 且つ 商品が出品中である' %> %>
   <% if user_signed_in? %>
-    <% if current_user.id == @item.user_id %>
-  
+    <% if current_user.id == @item.user_id %> 
           <%# 商品編集削除ボタン %>
-        <%= link_to "商品の編集", item_path, method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", item_path, method: :delete, class:"item-destroy" %>
         <% else %>
@@ -41,11 +38,8 @@
    <% end %>
   <% end %>
 
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
# What
商品情報編集機能

# Why

edit　修正
コメントアウト、不要であれば2箇所削除



show、edit、updateアクション内に同じ記述が存在している、メソッドを新しく作成し、before_actionで呼び出す修正。
redirect_to root_path unless current_user.id == @item.user_id
updateアクションにも適用されるように実装(新しくメソッドを定義し、before_actionで呼び出しましょう。)




必要な情報を適切に入力すると、商品情報（商品画像・商品名・商品の状態など）を変更できること
https://gyazo.com/7429f0e5207ad47d36a759ded0bb861e
何も編集せずに更新をしても画像無しの商品にならないこと
https://gyazo.com/49229e9cfdbf80c0c9f2e658c0f2f7fd
ログイン状態の出品者だけが商品情報編集ページに遷移できること
https://gyazo.com/b1db978751688e8abd72827dba2d5889
https://gyazo.com/3440cc29644e466649d09a21a5b5986e
ログイン状態の出品者以外のユーザーは、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること
https://gyazo.com/881f0e70900d62c43c36c0c8a22b0084
ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移すること
https://gyazo.com/331d27944c4149733bee988a22f3f28f

商品出品時とほぼ同じ見た目で商品情報編集機能が実装されていること
https://gyazo.com/cd8788b1f565ef545df25d3304a4ba73
商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示されること（画像に関しては、表示されない状態で良い）
https://gyazo.com/cd8788b1f565ef545df25d3304a4ba73
エラーハンドリングができていること（適切では無い値が入力された場合、情報は保存されず、エラーメッセージを出力させること）
エラーメッセージの出力は、商品情報編集ページにて行うこと
https://gyazo.com/5a86fe3c489d6f93b303c7381f84f766
